### PR TITLE
Add NodeJS 4.4 to travis build grid to ensure compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "4.4"
   - "5.2"
 
 before_install:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "browserify": "^13.0.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.10.2",
-    "eslint-plugin-jsx-a11y": "^1.5.5",
     "eslint-plugin-react": "^5.2.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
-    "eslint": "^3.0.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.10.2",
     "eslint-plugin-jsx-a11y": "^1.5.5",


### PR DESCRIPTION
This project should be compatible with NodeJS 4.4.x because is the LTS version used in most projects.
